### PR TITLE
Add transformers package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tqdm
 datasets==2.12.0
 onnxruntime-gpu==1.15.1
 torch==2.0.0
+transformers==4.29.2


### PR DESCRIPTION
I couldn't load the gpt2m.pt model with version 4.30.  But with 4.29 it does work and this version is mentioned in https://huggingface.co/commaai/commavq-gpt2m/blob/main/config.json