### PR TITLE
vqvae.py utility, white-box, nonlinearity, Normalize

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,30 @@
+name: Test Coverage CI
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run coverage script
+      shell: pwsh
+      run: |
+        ./scripts/run_coverage.ps1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,3 +28,12 @@ jobs:
       shell: pwsh
       run: |
         ./scripts/run_coverage.ps1
+
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: coverage-reports
+        path: |
+          tests/coverage_report_html/
+          tests/coverage.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,13 +23,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        # Test deps for tests/test_roundtrip_ssim.py:
-        #   einops          - required by utils/vqvae.py
-        #   opencv-python   - required by utils/video.py (read_video / transform_img)
-        #   scikit-image    - structural_similarity for the SSIM round-trip test
-        #   numpy<2         - pinned for ABI compatibility with torch==2.2.2
-        #   pytest, pytest-cov - test runner and coverage reporting
-        pip install einops opencv-python scikit-image "numpy<2" pytest pytest-cov
 
     - name: Run coverage script
       shell: pwsh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        # Test deps for tests/test_roundtrip_ssim.py:
+        #   einops          - required by utils/vqvae.py
+        #   opencv-python   - required by utils/video.py (read_video / transform_img)
+        #   scikit-image    - structural_similarity for the SSIM round-trip test
+        #   numpy<2         - pinned for ABI compatibility with torch==2.2.2
+        #   pytest, pytest-cov - test runner and coverage reporting
+        pip install einops opencv-python scikit-image "numpy<2" pytest pytest-cov
 
     - name: Run coverage script
       shell: pwsh

--- a/docs/VV_CICD
+++ b/docs/VV_CICD
@@ -1,0 +1,72 @@
+CI/CD and Testing Documentation: commaVQ
+Overveiw:
+The commaVQ repository facilitates the compression of driving scenes into tokens for use in world models.To maintain the integrity of these models we have implemented an automated pipeline that validates every change.
+CI/CD Pipeline Integration
+TO make sure every change is set to the standards of Verification and Validation, we used GitHub Actions workflow
+Goal: Confirm the test plan, architecture, and interface contracts are internally consistent before code execution
+
+1.1 Decoder Forward-Pass Pipeline
+The decoder must follow a strict sequential order to reconstruct images from encoding_indices. A failure in this ordering leads to catastrophic reconstruction error.
+
+Execution Order:
+
+Quantize: (B, 128) IDs → (B, 128, 256) embeddings.
+
+Reshape: Rearrange to (B, 256, 8, 16).
+
+Refine: post_quant_conv (1x1) → conv_in (3x3).
+
+Process: Mid-stack (Resnet + Attention).
+
+Upsample: Four stages (8x16 → 128x256).
+
+Finalize: GroupNorm → Swish → Conv2d (3x3) → Scale to [0, 255].
+
+Pipeline Architecture
+Review 1.1.1 Pipeline diagram in docs/vv_plan.md
+
+1.2 Shape Algebra Verification
+Dimensions are tracked at each bottleneck to ensure no data is dropped or misaligned.
+Stage
+Expected Shape
+Input Indices
+(B, 128)
+Latent Space
+(B, 256, 8, 16)
+Upsample 1
+(B, *, 16, 32)
+Upsample 4
+(B, *, 128, 256)
+Final RGB
+(B, 3, 128, 256)
+
+
+Phase 2 — Implementation Validation (Executable Tests)
+
+Goal: Convert design contracts into automated pytest assertions.
+
+2.1 Test Suite Structure
+Tests are compartmentalized to isolate model logic from video utility logic.
+test_decoder_forward.py: Validates shapes and tensor ranges.
+test_upsample.py: Ensures the $2 \times$ spatial expansion logic is mathematically sound.
+test_video_utils.py: Checks for color space consistency (BGR vs RGB).
+test_roundtrip_ssim.py: The "Slow" end-to-end quality check.
+2.2 Critical Test Definitions
+
+SSIM Roundtrip: We perform an Encode → Decode cycle on real driving frames.
+Success Metric: $SSIM \geq 0.6$ (Initial Threshold).
+Significance: This is the ultimate proof that the compressor preserves the visual features necessary for world modeling.
+Color Inversion Check: Validates that write_video correctly inverts the read_video color space. Without this, the model "sees" inverted colors, leading to catastrophic failure in downstream driving predictions.
+
+
+
+3. Summary of Progress (What has been done)
+We have successfully established the following:
+
+Architecture Alignment: Confirmed that the Decoder pipeline in utils/vqvae.py matches the design specs for 4-stage upsampling.
+
+Infrastructure Setup: Created the tests/ directory and conftest.py to provide stable mock data, preventing the need for large downloads during unit testing.
+
+CI/CD Foundation: Configured the environment to run pytest automatically on push.
+
+Utility Hardening: Verified that transform_img correctly normalizes varying input aspect ratios (e.g., 1080p, 720p) into the required (128, 256) resolution.

--- a/docs/vv_plan.md
+++ b/docs/vv_plan.md
@@ -1,0 +1,210 @@
+# Verification & Validation Plan
+
+This document is the V&V plan for the commavq compressor. It is split into a
+**design phase** (specification review, no code execution) and an
+**implementation phase** (executable tests run against the real code).
+
+---
+
+## Phase 1 — Design Verification (review-only)
+
+Goal: confirm the test plan, architecture, constraints, and interface
+contracts are internally consistent *before* any tests are executed.
+
+Deliverable: a checklist of PASS / FAIL / FLAG entries recorded in
+[docs/vv_design_review.md](vv_design_review.md) once the review is performed.
+
+### 1.1 Decoder forward-pass pipeline ordering
+
+Review [utils/vqvae.py:302-334](../utils/vqvae.py#L302-L334) (`Decoder.forward`)
+and confirm the pipeline executes in this order:
+
+1. `quantize.decode(encoding_indices)` — `(B, 128)` int IDs → `(B, 128, 256)` embeddings
+2. `rearrange('b (h w) c -> b c h w', w=quantized_resolution)` → `(B, 256, 8, 16)`
+3. `post_quant_conv` (1x1 Conv2d, 256→256)
+4. `conv_in` (3x3 Conv2d, 256→512)
+5. Mid stack: `mid.block_1` → `mid.attn_1` → `mid.block_2`
+6. Four `Upsample` stages, one per `i_level` in `{4, 3, 2, 1}` (no upsample at `i_level=0`)
+7. `norm_out` → `nonlinearity (swish)` → `conv_out` (3x3 Conv2d, 128→3)
+8. Output scaling: `((h + 1.0) / 2.0) * 255.`
+
+### 1.1.1 Pipeline diagram
+
+```mermaid
+flowchart TD
+    A["encoding_indices (B, 128) int64"]
+    B["quantize.decode<br/>→ (B, 128, 256)"]
+    C["rearrange 'b (h w) c → b c h w', w=16<br/>→ (B, 256, 8, 16)"]
+    D["post_quant_conv: Conv2d 1×1, 256→256"]
+    E["conv_in: Conv2d 3×3, 256→512<br/>→ (B, 512, 8, 16)"]
+    F["mid.block_1: ResnetBlock 512→512"]
+    G["mid.attn_1: AttnBlock 512"]
+    H["mid.block_2: ResnetBlock 512→512"]
+    I["up[4]: 3× (ResnetBlock 512→512 + AttnBlock@res=16)<br/>then Upsample ×2 → (B, 512, 16, 32)"]
+    J["up[3]: ResnetBlock 512→256, 256→256, 256→256<br/>then Upsample ×2 → (B, 256, 32, 64)"]
+    K["up[2]: 3× ResnetBlock 256→256<br/>then Upsample ×2 → (B, 256, 64, 128)"]
+    L["up[1]: ResnetBlock 256→128, 128→128, 128→128<br/>then Upsample ×2 → (B, 128, 128, 256)"]
+    M["up[0]: 3× ResnetBlock 128→128<br/>(no upsample)"]
+    N["norm_out: GroupNorm(32)"]
+    O["nonlinearity: swish (x · σ(x))"]
+    P["conv_out: Conv2d 3×3, 128→3<br/>→ (B, 3, 128, 256) float"]
+    Q["scale: ((h + 1.0) / 2.0) × 255"]
+    R["RGB image (B, 3, 128, 256)"]
+
+    A --> B --> C --> D --> E --> F --> G --> H
+    H --> I --> J --> K --> L --> M
+    M --> N --> O --> P --> Q --> R
+```
+
+Each `Upsample` block expands `(H, W) -> (2H, 2W)` via
+`F.interpolate(mode="nearest")` followed by a stride-1 3x3 Conv2d that
+preserves channels. The four upsamples take `8x16 -> 16x32 -> 32x64 ->
+64x128 -> 128x256`.
+
+### 1.2 Shape algebra
+
+Walk the dimensions through the pipeline and confirm:
+
+| Stage                              | Shape              |
+| ---------------------------------- | ------------------ |
+| input encoding indices             | `(B, 128)`         |
+| after `quantize.decode`            | `(B, 128, 256)`    |
+| after `rearrange` (w=16)           | `(B, 256, 8, 16)`  |
+| after `post_quant_conv` / `conv_in`| `(B, 512, 8, 16)`  |
+| after upsample x1                  | `(B, *, 16, 32)`   |
+| after upsample x2                  | `(B, *, 32, 64)`   |
+| after upsample x3                  | `(B, *, 64, 128)`  |
+| after upsample x4                  | `(B, *, 128, 256)` |
+| after `conv_out` + scale           | `(B, 3, 128, 256)` |
+
+### 1.3 `Upsample` contract
+
+Review [utils/vqvae.py:36-42](../utils/vqvae.py#L36-L42) and confirm:
+
+- Spatial dims double via `F.interpolate(scale_factor=2.0, mode="nearest")`.
+- Channels unchanged (`in_channels == out_channels`).
+- Followed by a stride-1 3x3 Conv2d with padding=1 (shape-preserving).
+
+### 1.4 `video.py` contracts
+
+Review [utils/video.py](../utils/video.py) and confirm:
+
+- `read_video` ([utils/video.py:17-27](../utils/video.py#L17-L27)) converts
+  OpenCV's native BGR to RGB via `cv2.COLOR_BGR2RGB`.
+- `write_video` ([utils/video.py:9-15](../utils/video.py#L9-L15)) inverts that
+  with `frame[...,::-1]` so the OpenCV writer receives BGR again.
+- `transpose_and_clip` ([utils/video.py:29-33](../utils/video.py#L29-L33))
+  reorders `(B, C, H, W) → (B, H, W, C)` and clips to `uint8 [0, 255]`.
+- `transform_img` ([utils/video.py:35-40](../utils/video.py#L35-L40))
+  produces a `(128, 256, 3)` array regardless of input aspect ratio
+  (cv2 `OUTPUT_SIZE` is `(W=256, H=128)` so the resulting numpy array is
+  `(H=128, W=256, 3)`).
+
+---
+
+## Phase 2 — Implementation Validation (executable tests)
+
+Goal: execute tests against the running code to validate the contracts that
+the design review verified on paper.
+
+### 2.1 Layout
+
+```
+tests/
+  conftest.py
+  test_decoder_forward.py
+  test_upsample.py
+  test_video_utils.py
+  test_roundtrip_ssim.py
+requirements-dev.txt
+```
+
+Run test
+```
+pip install pytest scikit-image
+pytest tests/test_roundtrip_ssim.py -m slow -v
+```
+
+`tests/conftest.py` provides:
+
+- A `CompressorConfig` fixture (real default config).
+- A fresh `Decoder` fixture with random weights so unit tests run without
+  downloading the checkpoint.
+- A fixed `torch.manual_seed` for reproducibility.
+
+### 2.2 `test_decoder_forward.py`
+
+- **`test_decoder_output_shape`** — feed
+  `torch.randint(0, vocab_size, (B, 128))` and assert output shape is
+  `(B, 3, 128, 256)`.
+- **`test_decoder_output_range`** — assert that after passing the raw decoder
+  output through `transpose_and_clip`, all values are in `[0, 255]` and
+  dtype is `uint8`. (Raw float output may overshoot with random weights;
+  the production path always goes through clipping.)
+- **`test_decoder_intermediate_z_shape`** — run a forward pass and assert
+  `decoder.last_z_shape == (B, 256, 8, 16)`.
+
+### 2.3 `test_upsample.py`
+
+- **`test_upsample_doubles_spatial`** — `Upsample(C)` on `(2, C, 4, 4)` returns
+  `(2, C, 8, 8)`; channel count unchanged.
+- **`test_upsample_nearest_neighbor`** — replace the inner conv with
+  `nn.Identity` (or set its weights to a centered impulse) and assert
+  `out[..., 2i, 2j] == in[..., i, j]` for all `i, j` and that each input
+  pixel is replicated to its 2x2 output block.
+
+### 2.4 `test_video_utils.py`
+
+- **`test_transform_img_shape`** — feed several aspect ratios
+  (e.g. `(874, 1164, 3)`, `(720, 1280, 3)`, `(1080, 1920, 3)`) and assert
+  output shape is `(128, 256, 3)` in every case.
+- **`test_transpose_and_clip`** — input `(B, 3, H, W)` float array containing
+  values `< 0` and `> 255`; assert output shape `(B, H, W, 3)`, dtype
+  `uint8`, and `min >= 0`, `max <= 255`.
+- **`test_read_write_video_color_roundtrip`** — write a small synthetic RGB
+  clip with `write_video`, read it back with `read_video`, and assert
+  per-channel mean is preserved within a loose tolerance (the codec is
+  lossy). This validates that the BGR↔RGB inversion in `write_video` is
+  the correct inverse of the conversion in `read_video`.
+
+### 2.5 `test_roundtrip_ssim.py` (marked `@pytest.mark.slow`)
+
+End-to-end encode→decode round trip on known driving frames.
+
+- Skip if `skimage` is unavailable or if the checkpoint cannot be downloaded.
+- Load real `Encoder` and `Decoder` via `load_state_dict_from_url`.
+- Use a small set of known frames (sourced from `examples/` or a small
+  fixture) processed by `transform_img`.
+- Encode → decode → `transpose_and_clip` → SSIM via
+  `skimage.metrics.structural_similarity` per frame.
+- Assert `mean(SSIM) >= THRESHOLD`. Initial threshold: **0.6** (placeholder),
+  to be tightened after a first measurement on real frames. The threshold is
+  intentionally loose because the compressor is lossy by design.
+
+### 2.6 Test dependencies
+
+Add `requirements-dev.txt`:
+
+```
+pytest
+scikit-image
+```
+
+Run:
+
+```
+pytest tests/ -q              # fast unit tests only
+pytest tests/ -q -m slow      # include the round-trip SSIM test
+```
+
+---
+
+## Open items to resolve before/while implementing
+
+1. **Row-major vs col-major wording** — the spec says "col-major"; the code is
+   row-major (einops). Tests will assert the code's actual behavior and the
+   design review will flag the wording mismatch.
+2. **SSIM threshold** — committed at `0.6` initially; re-tune after the first
+   real measurement.
+3. **Network access for the round-trip test** — gated behind
+   `pytest.mark.slow` and a `skipif` when the checkpoint download fails.

--- a/download_dataset.py
+++ b/download_dataset.py
@@ -1,0 +1,7 @@
+import numpy as np
+from datasets import load_dataset
+# load the first shard
+data_files = {'train': ['data-0000.tar.gz']}
+ds = load_dataset('commaai/commavq', data_files=data_files)
+tokens = np.array(ds['train'][0]['token.npy'])
+poses = np.array(ds['train'][0]['pose.npy'])

--- a/groupJ_README.md
+++ b/groupJ_README.md
@@ -1,0 +1,25 @@
+# environment scrips in the scripts directory
+
+## setup_env.ps1
+creates the virtual environment and installs depenencies. 
+
+## activate_env.ps1
+activates the environment
+
+## run_coverage.ps1
+runs the tests in the tests directory and outputs the coverage report in the test directory.
+you have to add new tests to this script.
+
+# to run the tests
+```
+.\scripts\setup_env.ps1
+.\scripts\activate_env.ps1
+.\scripts\run_coverage.ps1
+```
+## a new coverage report is written to:
+```
+.\tests\coverage_report_html\index.html
+```
+
+# download_dataset.py
+run this to get the hugging face dataset

--- a/groupJ_README.md
+++ b/groupJ_README.md
@@ -1,25 +1,52 @@
-# environment scrips in the scripts directory
+# environment scripts in the scripts directory
 
-## setup_env.ps1
-creates the virtual environment and installs depenencies. 
+## Windows (PowerShell)
 
-## activate_env.ps1
-activates the environment
+### setup_env.ps1
+Creates the virtual environment and installs dependencies.
 
-## run_coverage.ps1
-runs the tests in the tests directory and outputs the coverage report in the test directory.
-you have to add new tests to this script.
+### activate_env.ps1
+Activates the environment.
 
-# to run the tests
+### run_coverage.ps1
+Runs the tests in the tests directory and outputs the coverage report in the test directory.
+You have to add new tests to this script.
+
+**To run the tests (from the repo root):**
+
 ```
 .\scripts\setup_env.ps1
 .\scripts\activate_env.ps1
 .\scripts\run_coverage.ps1
 ```
-## a new coverage report is written to:
+
+## macOS / Linux (bash)
+
+### setup_env.sh
+Same as `setup_env.ps1`: creates `venv` and installs from `requirements.txt`.
+
+### activate_env.sh
+Same as `activate_env.ps1`: opens a new shell with the virtual environment activated.
+
+### run_coverage.sh
+Same as `run_coverage.ps1`: runs pytest with coverage for the configured tests.
+
+**To run the tests (from the repo root):**
+
 ```
-.\tests\coverage_report_html\index.html
+./scripts/setup_env.sh
+./scripts/activate_env.sh
+./scripts/run_coverage.sh
+```
+
+## coverage report output
+
+A new HTML coverage report is written to:
+
+```
+tests/coverage_report_html/index.html
 ```
 
 # download_dataset.py
-run this to get the hugging face dataset
+
+Run this to get the hugging face dataset.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 tqdm
 datasets==4.0.0
-torch==2.2.2
+torch
+opencv-python
+einops
+pytest
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 tqdm
 datasets==4.0.0
 torch
-opencv-python
+opencv-python-headless
 einops
+scikit-image
 pytest
 pytest-cov

--- a/scripts/activate_env.ps1
+++ b/scripts/activate_env.ps1
@@ -1,0 +1,12 @@
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Set-Location "$ScriptDir\.."
+
+if (-Not (Test-Path "venv\Scripts\Activate.ps1")) {
+    Write-Host "Virtual environment not found. Please run scripts\setup_env.ps1 first."
+    Read-Host -Prompt "Press Enter to exit"
+    exit
+}
+
+Write-Host "Opening a new PowerShell session with the virtual environment activated..."
+# Start a new PowerShell session that loads the activation script and stays open
+powershell.exe -NoExit -Command ". '.\venv\Scripts\Activate.ps1'"

--- a/scripts/activate_env.sh
+++ b/scripts/activate_env.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -f "$ROOT/venv/bin/activate" ]; then
+  echo "Virtual environment not found. Please run scripts/setup_env.sh first."
+  read -r -p "Press Enter to exit"
+  exit 1
+fi
+
+echo "Opening a new shell session with the virtual environment activated..."
+cd "$ROOT" || exit 1
+exec "$SHELL" -c "source '$ROOT/venv/bin/activate'; exec $SHELL -i"

--- a/scripts/run_coverage.ps1
+++ b/scripts/run_coverage.ps1
@@ -1,0 +1,6 @@
+# Set the execution policy if needed, though running as a simple script
+# This script runs pytest with coverage on the utils.vqvae module
+
+# Using python -m pytest ensures the current directory is securely added to the python path
+$env:PYTHONPATH = ".;$env:PYTHONPATH"
+python -m pytest tests/test_compressor_config.py --cov=utils.vqvae --cov-report=term-missing --cov-report=html:tests/coverage_report_html --cov-report=xml:tests/coverage.xml

--- a/scripts/run_coverage.ps1
+++ b/scripts/run_coverage.ps1
@@ -3,4 +3,4 @@
 
 # Using python -m pytest ensures the current directory is securely added to the python path
 $env:PYTHONPATH = ".;$env:PYTHONPATH"
-python -m pytest tests/test_compressor_config.py --cov=utils.vqvae --cov-report=term-missing --cov-report=html:tests/coverage_report_html --cov-report=xml:tests/coverage.xml
+python -m pytest tests/test_compressor_config.py tests/test_roundtrip_ssim.py -v --cov=utils.vqvae --cov-report=term-missing --cov-report=html:tests/coverage_report_html --cov-report=xml:tests/coverage.xml

--- a/scripts/run_coverage.ps1
+++ b/scripts/run_coverage.ps1
@@ -3,4 +3,4 @@
 
 # Using python -m pytest ensures the current directory is securely added to the python path
 $env:PYTHONPATH = ".;$env:PYTHONPATH"
-python -m pytest tests/test_compressor_config.py tests/test_roundtrip_ssim.py -v --cov=utils.vqvae --cov-report=term-missing --cov-report=html:tests/coverage_report_html --cov-report=xml:tests/coverage.xml
+python -m pytest tests/ -v --cov=utils.vqvae --cov-report=term-missing --cov-report=html:tests/coverage_report_html --cov-report=xml:tests/coverage.xml

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+export PYTHONPATH=".:${PYTHONPATH:-}"
+
+if [ -x "venv/bin/python3" ]; then
+  PY="venv/bin/python3"
+else
+  PY="python3"
+fi
+
+"$PY" -m pytest tests/test_compressor_config.py \
+  --cov=utils.vqvae \
+  --cov-report=term-missing \
+  --cov-report=html:tests/coverage_report_html \
+  --cov-report=xml:tests/coverage.xml

--- a/scripts/setup_env.ps1
+++ b/scripts/setup_env.ps1
@@ -1,0 +1,10 @@
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Set-Location "$ScriptDir\.."
+
+Write-Host "Setting up the virtual environment..."
+python -m venv venv
+
+# run pip directly from the virtual environment
+& .\venv\Scripts\pip.exe install -r requirements.txt
+
+Write-Host "Setup complete."

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+echo "Setting up the virtual environment..."
+python3 -m venv venv
+
+./venv/bin/pip install -r requirements.txt
+
+echo "Setup complete."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Shared pytest setup for the V&V test suite."""
 
 import sys
+import torch
+import pytest
 from pathlib import Path
 
 # Make the repo root importable so tests can do `from utils.vqvae import ...`
@@ -9,6 +11,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
   sys.path.insert(0, str(REPO_ROOT))
 
+from utils.vqvae import (
+    CompressorConfig, ResnetBlock, AttnBlock, 
+    Downsample, Upsample, VectorQuantizer, Encoder, Decoder
+)
 
 def pytest_configure(config):
   """Register custom markers so pytest doesn't warn about them."""
@@ -16,3 +22,68 @@ def pytest_configure(config):
     "markers",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
   )
+
+@pytest.fixture
+def tiny_config():
+    """Returns a minimal CompressorConfig for fast architecture testing."""
+    return CompressorConfig(
+        in_channels=3, out_channels=3, ch_mult=(1, 2),
+        attn_resolutions=(4,), resolution=8, num_res_blocks=1,
+        z_channels=32, vocab_size=8, ch=32, dropout=0.0,
+    )
+
+@pytest.fixture
+def dummy_image_tensor(tiny_config):
+    """Returns a synthetic image tensor (B, C, H, W)."""
+    torch.manual_seed(0)
+    return torch.randn(2, tiny_config.in_channels, tiny_config.resolution, tiny_config.resolution)
+
+@pytest.fixture
+def dummy_feature_tensor():
+    """Returns a standard feature-map intermediate tensor (B=2, C=32, H=8, W=8)."""
+    torch.manual_seed(0)
+    return torch.randn(2, 32, 8, 8)
+
+@pytest.fixture
+def resnet_block():
+    """Default ResnetBlock preserving shape/channels."""
+    return ResnetBlock(in_channels=32, out_channels=32, dropout=0.0, temb_channels=64)
+
+@pytest.fixture
+def attn_block():
+    """Default AttnBlock."""
+    return AttnBlock(in_channels=32)
+
+@pytest.fixture
+def downsample():
+    """Default Downsample block."""
+    return Downsample(in_channels=16)
+
+@pytest.fixture
+def upsample():
+    """Default Upsample block."""
+    upsample = Upsample(in_channels=1)
+    upsample.conv.weight.data.fill_(1.0)
+    if upsample.conv.bias is not None:
+        upsample.conv.bias.data.zero_()
+    return upsample
+
+@pytest.fixture
+def vector_quantizer():
+    """Pre-initialized VectorQuantizer with small dummy embeddings."""
+    vq = VectorQuantizer(num_embeddings=3, embedding_dim=2)
+    with torch.no_grad():
+        vq._embedding.weight.copy_(
+            torch.tensor([[0.0, 0.0], [2.0, 2.0], [-2.0, -2.0]])
+        )
+    return vq
+
+@pytest.fixture
+def encoder(tiny_config):
+    """Spatially scaled down Encoder."""
+    return Encoder(tiny_config)
+
+@pytest.fixture
+def decoder(tiny_config):
+    """Spatially scaled down Decoder."""
+    return Decoder(tiny_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest setup for the V&V test suite."""
+
+import sys
+from pathlib import Path
+
+# Make the repo root importable so tests can do `from utils.vqvae import ...`
+# without needing the package to be pip-installed.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+  sys.path.insert(0, str(REPO_ROOT))
+
+
+def pytest_configure(config):
+  """Register custom markers so pytest doesn't warn about them."""
+  config.addinivalue_line(
+    "markers",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  )

--- a/tests/limitations_and_risks.md
+++ b/tests/limitations_and_risks.md
@@ -1,0 +1,48 @@
+# Limitations & Risks
+
+## 1. Limitations
+
+The current testing approach provides component-level validation for the VQ-VAE video compression system, with emphasis on tensor shape correctness, module behavior, and data flow through individual submodules. The following limitations remain:
+
+- Full end-to-end pipeline testing of the Encoder, VectorQuantizer, and Decoder sequence is not yet fully covered.
+- Test inputs are small, controlled tensors rather than representative real-world video datasets.
+- Performance and scalability testing are not included, including CPU versus GPU behavior and large batch or high-resolution input handling.
+- Integration testing between major components is limited, so some cross-component interface issues may not be detected.
+- Current tests focus on functional correctness and structural validation rather than compression quality, training stability, or production deployment behavior.
+
+## 2. Risks
+
+The following risks may affect the reliability of the system if not addressed through expanded validation:
+
+- Silent tensor shape or data flow errors could occur when components are combined in configurations not covered by the current tests.
+- VectorQuantizer behavior may be non-deterministic or sensitive to initialization, which can make exact output comparison unreliable.
+- Environment and dependency inconsistencies may cause tests to pass in one setup but fail under a different Python, PyTorch, CUDA, or hardware configuration.
+- Lack of large-scale testing may hide memory, runtime, or numerical stability issues that only appear with realistic datasets.
+- Limited integration coverage may allow interface mismatches between Encoder, VectorQuantizer, and Decoder modules to remain undetected.
+
+## 3. Mitigation Strategies
+
+The team reduces these risks through targeted validation and controlled test practices:
+
+- Tensor shape assertions and validation checks are used to confirm that each tested component produces expected output dimensions.
+- Data flow checks verify that submodules accept and return tensors in the expected format.
+- For components with non-deterministic behavior, tests emphasize consistency of structure, valid ranges, and expected properties instead of exact output values.
+- Controlled test environments and dependency version pinning reduce the likelihood of inconsistent behavior across development machines.
+- Partial integration tests help validate selected interactions between modules while broader end-to-end coverage is still being developed.
+
+## 4. Impact
+
+These limitations and risks matter because the system is intended to operate on complex video data where small component-level errors can propagate through the compression pipeline. A model that passes isolated unit tests may still fail when processing realistic video inputs, larger datasets, or different hardware configurations.
+
+If these risks are not addressed, the system may experience reduced reliability, unexpected runtime failures, degraded compression quality, or inconsistent behavior across environments. This could limit confidence in the test results and reduce the effectiveness of the Software Test Plan as evidence of system readiness.
+
+## 5. Future Improvements
+
+Future testing work should expand coverage in the following areas:
+
+- Add full end-to-end tests covering the Encoder, VectorQuantizer, and Decoder pipeline.
+- Incorporate representative real-world video datasets and more varied input conditions.
+- Add performance benchmarks for CPU and GPU execution, memory usage, throughput, and scalability.
+- Expand integration tests across major model components and configuration variants.
+- Add tests that evaluate reconstruction quality and compression-related metrics where appropriate.
+- Validate behavior across pinned dependency versions and supported hardware environments.

--- a/tests/test_attn_block.py
+++ b/tests/test_attn_block.py
@@ -1,0 +1,46 @@
+import torch
+
+from utils.vqvae import AttnBlock
+
+
+def test_attn_block_preserves_shape():
+  """
+  AttnBlock should preserve the input tensor's shape.
+  """
+  torch.manual_seed(0)
+
+  block = AttnBlock(in_channels=32)
+
+  x = torch.randn(2, 32, 8, 8)
+
+  out = block(x)
+
+  assert out.shape == x.shape
+
+
+def test_attn_block_changes_output():
+  """
+  AttnBlock should modify the input via residual attention.
+  """
+  torch.manual_seed(0)
+
+  block = AttnBlock(in_channels=32)
+
+  x = torch.randn(2, 32, 8, 8)
+
+  out = block(x)
+
+  assert not torch.allclose(out, x)
+
+
+def test_attn_block_different_channels():
+  """
+  AttnBlock should work with different channel counts.
+  """
+  torch.manual_seed(0)
+
+  for ch in [32, 64, 128]:
+    block = AttnBlock(in_channels=ch)
+    x = torch.randn(1, ch, 4, 4)
+    out = block(x)
+    assert out.shape == x.shape

--- a/tests/test_attn_block.py
+++ b/tests/test_attn_block.py
@@ -2,36 +2,19 @@ import torch
 
 from utils.vqvae import AttnBlock
 
-
-def test_attn_block_preserves_shape():
+def test_attn_block_preserves_shape(attn_block, dummy_feature_tensor):
   """
   AttnBlock should preserve the input tensor's shape.
   """
-  torch.manual_seed(0)
+  out = attn_block(dummy_feature_tensor)
+  assert out.shape == dummy_feature_tensor.shape
 
-  block = AttnBlock(in_channels=32)
-
-  x = torch.randn(2, 32, 8, 8)
-
-  out = block(x)
-
-  assert out.shape == x.shape
-
-
-def test_attn_block_changes_output():
+def test_attn_block_changes_output(attn_block, dummy_feature_tensor):
   """
   AttnBlock should modify the input via residual attention.
   """
-  torch.manual_seed(0)
-
-  block = AttnBlock(in_channels=32)
-
-  x = torch.randn(2, 32, 8, 8)
-
-  out = block(x)
-
-  assert not torch.allclose(out, x)
-
+  out = attn_block(dummy_feature_tensor)
+  assert not torch.allclose(out, dummy_feature_tensor)
 
 def test_attn_block_different_channels():
   """

--- a/tests/test_compressor_config.py
+++ b/tests/test_compressor_config.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+from utils.vqvae import CompressorConfig
+
+def test_compressor_config_defaults():
+    """
+    simple test for CompressorConfig
+    """
+    config = CompressorConfig()
+    
+    # Test default properties
+    assert config.in_channels == 3
+    assert config.out_channels == 3
+    assert config.resolution == 256
+    assert config.vocab_size == 1024
+    assert config.ch_mult == (1, 1, 2, 2, 4)
+    
+    # Test computed properties
+    assert config.num_resolutions == 5  
+    
+    # quantized_resolution = resolution // 2**(num_resolutions-1)
+    # 256 // 2**(5-1) = 256 // 16 = 16
+    assert config.quantized_resolution == 16

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -2,23 +2,18 @@ import torch
 
 from utils.vqvae import Downsample
 
-
-def test_downsample_even_input_reduces_spatial_dimensions():
+def test_downsample_even_input_reduces_spatial_dimensions(downsample):
     """
     Downsample should halve height and width for an even-sized input while
     preserving batch and channel dimensions.
     """
     torch.manual_seed(0)
-
-    down = Downsample(in_channels=16)
     x = torch.randn(2, 16, 8, 8)
-
-    out = down(x)
+    out = downsample(x)
 
     assert out.shape == (2, 16, 4, 4)
     assert out.dtype == x.dtype
     assert out.device == x.device
-
 
 def test_downsample_odd_input_uses_asymmetric_padding():
     """

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -1,0 +1,37 @@
+import torch
+
+from utils.vqvae import Downsample
+
+
+def test_downsample_even_input_reduces_spatial_dimensions():
+    """
+    Downsample should halve height and width for an even-sized input while
+    preserving batch and channel dimensions.
+    """
+    torch.manual_seed(0)
+
+    down = Downsample(in_channels=16)
+    x = torch.randn(2, 16, 8, 8)
+
+    out = down(x)
+
+    assert out.shape == (2, 16, 4, 4)
+    assert out.dtype == x.dtype
+    assert out.device == x.device
+
+
+def test_downsample_odd_input_uses_asymmetric_padding():
+    """
+    Downsample should pad odd-sized inputs on the right and bottom before
+    applying the stride-2 convolution.
+    """
+    down = Downsample(in_channels=1)
+    down.conv.weight.data.fill_(1.0)
+    if down.conv.bias is not None:
+        down.conv.bias.data.zero_()
+
+    x = torch.ones(1, 1, 5, 5)
+    out = down(x)
+
+    assert out.shape == (1, 1, 2, 2)
+    assert torch.allclose(out, torch.full_like(out, 9.0))

--- a/tests/test_resnet_block.py
+++ b/tests/test_resnet_block.py
@@ -1,0 +1,61 @@
+import torch
+
+from utils.vqvae import ResnetBlock
+
+
+def test_resnet_block_preserves_shape_and_uses_temb():
+  """
+  ResnetBlock should preserve spatial/channel shape when in/out channels match,
+  and a provided timestep embedding should influence the output.
+  """
+  torch.manual_seed(0)
+
+  block = ResnetBlock(
+    in_channels=32,
+    out_channels=32,
+    dropout=0.0,
+    temb_channels=64,
+  )
+
+  x = torch.randn(2, 32, 8, 8)
+  temb = torch.randn(2, 64)
+
+  out_with_temb = block(x, temb)
+  out_without_temb = block(x, None)
+
+  assert out_with_temb.shape == x.shape
+  assert out_without_temb.shape == x.shape
+  assert not torch.allclose(out_with_temb, out_without_temb)
+
+
+def test_resnet_block_channel_change_supports_both_shortcuts():
+  """
+  When channels change, ResnetBlock should project the residual path and return
+  tensors with the requested out_channels for both shortcut variants.
+  """
+  x = torch.randn(2, 32, 8, 8)
+
+  nin_block = ResnetBlock(
+    in_channels=32,
+    out_channels=64,
+    conv_shortcut=False,
+    dropout=0.0,
+    temb_channels=0,
+  )
+  assert hasattr(nin_block, "nin_shortcut")
+  assert not hasattr(nin_block, "conv_shortcut")
+  nin_out = nin_block(x, None)
+  assert nin_out.shape == (2, 64, 8, 8)
+
+  conv_block = ResnetBlock(
+    in_channels=32,
+    out_channels=64,
+    conv_shortcut=True,
+    dropout=0.0,
+    temb_channels=0,
+  )
+  assert hasattr(conv_block, "conv_shortcut")
+  assert not hasattr(conv_block, "nin_shortcut")
+  conv_out = conv_block(x, None)
+  assert conv_out.shape == (2, 64, 8, 8)
+

--- a/tests/test_resnet_block.py
+++ b/tests/test_resnet_block.py
@@ -2,39 +2,28 @@ import torch
 
 from utils.vqvae import ResnetBlock
 
-
-def test_resnet_block_preserves_shape_and_uses_temb():
+def test_resnet_block_preserves_shape_and_uses_temb(resnet_block, dummy_feature_tensor):
   """
   ResnetBlock should preserve spatial/channel shape when in/out channels match,
   and a provided timestep embedding should influence the output.
   """
   torch.manual_seed(0)
 
-  block = ResnetBlock(
-    in_channels=32,
-    out_channels=32,
-    dropout=0.0,
-    temb_channels=64,
-  )
-
-  x = torch.randn(2, 32, 8, 8)
   temb = torch.randn(2, 64)
 
-  out_with_temb = block(x, temb)
-  out_without_temb = block(x, None)
+  out_with_temb = resnet_block(dummy_feature_tensor, temb)
+  out_without_temb = resnet_block(dummy_feature_tensor, None)
 
-  assert out_with_temb.shape == x.shape
-  assert out_without_temb.shape == x.shape
+  assert out_with_temb.shape == dummy_feature_tensor.shape
+  assert out_without_temb.shape == dummy_feature_tensor.shape
   assert not torch.allclose(out_with_temb, out_without_temb)
 
 
-def test_resnet_block_channel_change_supports_both_shortcuts():
+def test_resnet_block_channel_change_supports_both_shortcuts(dummy_feature_tensor):
   """
   When channels change, ResnetBlock should project the residual path and return
   tensors with the requested out_channels for both shortcut variants.
   """
-  x = torch.randn(2, 32, 8, 8)
-
   nin_block = ResnetBlock(
     in_channels=32,
     out_channels=64,
@@ -44,7 +33,7 @@ def test_resnet_block_channel_change_supports_both_shortcuts():
   )
   assert hasattr(nin_block, "nin_shortcut")
   assert not hasattr(nin_block, "conv_shortcut")
-  nin_out = nin_block(x, None)
+  nin_out = nin_block(dummy_feature_tensor, None)
   assert nin_out.shape == (2, 64, 8, 8)
 
   conv_block = ResnetBlock(
@@ -56,6 +45,5 @@ def test_resnet_block_channel_change_supports_both_shortcuts():
   )
   assert hasattr(conv_block, "conv_shortcut")
   assert not hasattr(conv_block, "nin_shortcut")
-  conv_out = conv_block(x, None)
+  conv_out = conv_block(dummy_feature_tensor, None)
   assert conv_out.shape == (2, 64, 8, 8)
-

--- a/tests/test_roundtrip_ssim.py
+++ b/tests/test_roundtrip_ssim.py
@@ -1,0 +1,105 @@
+"""
+End-to-end encode -> decode round-trip validation via SSIM.
+
+This is the most important validation test in the suite: it loads the real
+trained checkpoints, runs known driving frames through the full compressor,
+and asserts that the reconstructed frames are visually similar to the
+originals (per Structural Similarity Index Measure).
+
+We start simple: decode the pre-computed tokens in examples/tokens.npy and
+compare against the source frames in examples/sample_video_ecamera.hevc.
+The tokens were produced by the encoder from that exact video, so this is a
+true round-trip even though we are not re-running the encoder here. Later
+we can extend the file to also re-encode frames on the fly.
+
+The test is marked `slow` and is skipped automatically when:
+  - scikit-image is not installed
+  - the decoder checkpoint cannot be downloaded
+  - OpenCV cannot decode the sample HEVC clip
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAMPLE_VIDEO = REPO_ROOT / "examples" / "sample_video_ecamera.hevc"
+SAMPLE_TOKENS = REPO_ROOT / "examples" / "tokens.npy"
+
+# Permissive starting threshold; tighten after a first real measurement.
+SSIM_THRESHOLD = 0.6
+# Keep the test fast: only round-trip a handful of frames.
+NUM_FRAMES = 5
+
+skimage = pytest.importorskip("skimage.metrics", reason="scikit-image not installed")
+
+
+@pytest.fixture(scope="module")
+def decoder():
+  """Load the real Decoder with pretrained weights, on CPU."""
+  from utils.vqvae import CompressorConfig, Decoder
+
+  config = CompressorConfig()
+  with torch.device("meta"):
+    model = Decoder(config)
+  try:
+    model.load_state_dict_from_url(assign=True)
+  except Exception as e:
+    pytest.skip(f"could not download decoder checkpoint: {e}")
+  return model.eval()
+
+
+@pytest.fixture(scope="module")
+def source_frames():
+  """Read the first NUM_FRAMES frames of the sample clip and run them
+  through transform_img so they line up with what the encoder originally saw."""
+  from utils.video import read_video, transform_img
+
+  if not SAMPLE_VIDEO.exists():
+    pytest.skip(f"sample video missing: {SAMPLE_VIDEO}")
+  try:
+    video = read_video(str(SAMPLE_VIDEO))
+  except Exception as e:
+    pytest.skip(f"OpenCV could not decode sample video: {e}")
+
+  frames = np.stack([transform_img(video[i]) for i in range(NUM_FRAMES)], axis=0)
+  # frames is (NUM_FRAMES, 128, 256, 3), uint8, RGB
+  assert frames.shape == (NUM_FRAMES, 128, 256, 3)
+  return frames
+
+
+@pytest.mark.slow
+def test_roundtrip_ssim_above_threshold(decoder, source_frames):
+  """Decode known tokens and assert per-frame SSIM is above the threshold."""
+  from utils.video import transpose_and_clip
+
+  if not SAMPLE_TOKENS.exists():
+    pytest.skip(f"sample tokens missing: {SAMPLE_TOKENS}")
+
+  tokens = np.load(SAMPLE_TOKENS).astype(np.int64)
+  assert tokens.shape[1] == 128, f"unexpected token shape: {tokens.shape}"
+
+  # Decode the same NUM_FRAMES frames in a single batched forward pass.
+  token_batch = torch.from_numpy(tokens[:NUM_FRAMES])
+  with torch.no_grad():
+    decoded = decoder(token_batch).cpu().numpy()
+  # decoded is (NUM_FRAMES, 3, 128, 256) float; convert to (N, H, W, C) uint8.
+  decoded = transpose_and_clip(decoded)
+  assert decoded.shape == source_frames.shape
+
+  # Per-frame SSIM, averaged over the batch. channel_axis=-1 treats the RGB
+  # channels jointly (one SSIM per frame, not per channel).
+  ssims = [
+    skimage.structural_similarity(
+      source_frames[i], decoded[i], channel_axis=-1, data_range=255
+    )
+    for i in range(NUM_FRAMES)
+  ]
+  mean_ssim = float(np.mean(ssims))
+
+  assert mean_ssim >= SSIM_THRESHOLD, (
+    f"round-trip SSIM {mean_ssim:.3f} below threshold {SSIM_THRESHOLD}; "
+    f"per-frame: {[round(s, 3) for s in ssims]}"
+  )

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from utils.video import transform_img, transpose_and_clip
+
+def test_transform_img_aspect_ratios():
+    """
+    Verifies that transform_img can handle various non-standard 
+    input aspect ratios and dimensions (portrait, square, ultrawide).
+    It must uniformly output images as (128, 256, 3) for the pipeline.
+    """
+    sizes = [
+        (1080, 1920, 3), # Portrait HD
+        (400, 400, 3),   # Square
+        (150, 600, 3),   # Extremely wide
+        (768, 512, 3),   # Random standard
+    ]
+    for size in sizes:
+        # Create dummy image data
+        frame = np.random.randint(0, 256, size, dtype=np.uint8)
+        out = transform_img(frame)
+        
+        # Verify OpenCV output format shape
+        assert out.shape == (128, 256, 3), (
+            f"Expected shape (128, 256, 3) for input size {size}, got {out.shape}"
+        )
+
+
+def test_transpose_and_clip():
+    """
+    Verifies that we correctly reorder axes from PyTorch tensors (N, C, H, W) 
+    back to standard frames (N, H, W, C) while safely clamping floating values 
+    strictly between [0, 255] and returning them as uint8. 
+    """
+    # Create crazy tensors stretching outside bounds -100 to 300
+    tensors = np.random.uniform(-100.0, 300.0, size=(2, 3, 10, 10))
+    
+    clipped = transpose_and_clip(tensors)
+    
+    # Check the axis reordering
+    assert clipped.shape == (2, 10, 10, 3)
+    
+    # Check clipping constraints
+    assert clipped.dtype == np.uint8
+    assert int(clipped.min()) >= 0
+    assert int(clipped.max()) <= 255

--- a/tests/test_vqvae_full_coverage.py
+++ b/tests/test_vqvae_full_coverage.py
@@ -12,6 +12,11 @@ from utils.vqvae import (
 
 
 def make_tiny_config():
+  """
+  Creates a minimal CompressorConfig for testing purposes.
+  By scaling down dimensions like resolution, z_channels, and vocab_size,
+  the tests can run extremely quickly while verifying the architecture.
+  """
   return CompressorConfig(
     in_channels=3,
     out_channels=3,
@@ -27,6 +32,11 @@ def make_tiny_config():
 
 
 def test_upsample_doubles_spatial_dimensions_and_runs_conv():
+  """
+  Verifies that the Upsample block correctly doubles the spatial dimensions 
+  (height and width) of the input tensor. By using predefined weights (1.0)
+  and zero bias, we can confidently assert the expected post-convolution matrix.
+  """
   upsample = Upsample(in_channels=1)
   upsample.conv.weight.data.fill_(1.0)
   if upsample.conv.bias is not None:
@@ -45,6 +55,12 @@ def test_upsample_doubles_spatial_dimensions_and_runs_conv():
 
 
 def test_vector_quantizer_encode_decode_and_embed_roundtrip():
+  """
+  Validates the full lifecycle of the VectorQuantizer. 
+  It sets up a mock embedding table manually and checks whether inputs 
+  are correctly assigned to the closest centroids (indices) and if they 
+  successfully reconstruct and fetch correct embeddings on the way out.
+  """
   quantizer = VectorQuantizer(num_embeddings=3, embedding_dim=2)
   with torch.no_grad():
     quantizer._embedding.weight.copy_(
@@ -87,6 +103,13 @@ def test_vector_quantizer_encode_decode_and_embed_roundtrip():
 
 
 def test_encoder_decoder_forward_with_tiny_config():
+  """
+  Tests an end-to-end forward pass matching an Encoder connected to a Decoder 
+  using randomly generated dummy image inputs. Checks that the encoded indices 
+  respect the defined vocabulary constraints, shape boundaries, and that the 
+  reconstructed output dimensions map faithfully to the original inputs while 
+  staying numerically sound (no NaNs).
+  """
   torch.manual_seed(0)
   config = make_tiny_config()
   encoder = Encoder(config)
@@ -111,6 +134,12 @@ def test_encoder_decoder_forward_with_tiny_config():
 
 
 def test_load_state_dict_from_url_delegates_to_torch_hub(monkeypatch):
+  """
+  Instead of hitting real URLs which would cause tests to fail without a network, 
+  this mocks out `torch.hub.load_state_dict_from_url` and verifies whether 
+  Encoder and Decoder delegate properly to load dict states using `weights_only=True` 
+  for security and memory mapping to `cpu`, effectively testing the integration.
+  """
   config = make_tiny_config()
   encoder = Encoder(config)
   decoder = Decoder(config)

--- a/tests/test_vqvae_full_coverage.py
+++ b/tests/test_vqvae_full_coverage.py
@@ -2,46 +2,13 @@ from unittest.mock import Mock
 
 import torch
 
-from utils.vqvae import (
-  CompressorConfig,
-  Decoder,
-  Encoder,
-  Upsample,
-  VectorQuantizer,
-)
 
-
-def make_tiny_config():
-  """
-  Creates a minimal CompressorConfig for testing purposes.
-  By scaling down dimensions like resolution, z_channels, and vocab_size,
-  the tests can run extremely quickly while verifying the architecture.
-  """
-  return CompressorConfig(
-    in_channels=3,
-    out_channels=3,
-    ch_mult=(1, 2),
-    attn_resolutions=(4,),
-    resolution=8,
-    num_res_blocks=1,
-    z_channels=32,
-    vocab_size=8,
-    ch=32,
-    dropout=0.0,
-  )
-
-
-def test_upsample_doubles_spatial_dimensions_and_runs_conv():
+def test_upsample_doubles_spatial_dimensions_and_runs_conv(upsample):
   """
   Verifies that the Upsample block correctly doubles the spatial dimensions 
   (height and width) of the input tensor. By using predefined weights (1.0)
   and zero bias, we can confidently assert the expected post-convolution matrix.
   """
-  upsample = Upsample(in_channels=1)
-  upsample.conv.weight.data.fill_(1.0)
-  if upsample.conv.bias is not None:
-    upsample.conv.bias.data.zero_()
-
   x = torch.ones(1, 1, 2, 2)
 
   out = upsample(x)
@@ -54,32 +21,22 @@ def test_upsample_doubles_spatial_dimensions_and_runs_conv():
   assert torch.allclose(out, expected)
 
 
-def test_vector_quantizer_encode_decode_and_embed_roundtrip():
+def test_vector_quantizer_encode_decode_and_embed_roundtrip(vector_quantizer):
   """
   Validates the full lifecycle of the VectorQuantizer. 
   It sets up a mock embedding table manually and checks whether inputs 
   are correctly assigned to the closest centroids (indices) and if they 
   successfully reconstruct and fetch correct embeddings on the way out.
   """
-  quantizer = VectorQuantizer(num_embeddings=3, embedding_dim=2)
-  with torch.no_grad():
-    quantizer._embedding.weight.copy_(
-      torch.tensor([
-        [0.0, 0.0],
-        [2.0, 2.0],
-        [-2.0, -2.0],
-      ])
-    )
-
   inputs = torch.tensor([[
     [0.1, 0.2],
     [2.2, 1.9],
     [-1.7, -2.1],
   ]])
 
-  quantized, indices = quantizer(inputs)
-  decoded, decoded_indices = quantizer.decode(indices)
-  embedded = quantizer.embed(torch.tensor([[1], [0], [2]]))
+  quantized, indices = vector_quantizer(inputs)
+  decoded, decoded_indices = vector_quantizer.decode(indices)
+  embedded = vector_quantizer.embed(torch.tensor([[1], [0], [2]]))
 
   assert torch.equal(indices, torch.tensor([[0, 1, 2]]))
   assert torch.equal(decoded_indices, indices)
@@ -102,7 +59,7 @@ def test_vector_quantizer_encode_decode_and_embed_roundtrip():
   )
 
 
-def test_encoder_decoder_forward_with_tiny_config():
+def test_encoder_decoder_forward_with_tiny_config(encoder, decoder, tiny_config, dummy_image_tensor):
   """
   Tests an end-to-end forward pass matching an Encoder connected to a Decoder 
   using randomly generated dummy image inputs. Checks that the encoded indices 
@@ -110,39 +67,30 @@ def test_encoder_decoder_forward_with_tiny_config():
   reconstructed output dimensions map faithfully to the original inputs while 
   staying numerically sound (no NaNs).
   """
-  torch.manual_seed(0)
-  config = make_tiny_config()
-  encoder = Encoder(config)
-  decoder = Decoder(config)
-  x = torch.randn(2, config.in_channels, config.resolution, config.resolution)
-
-  encoding_indices = encoder(x)
+  encoding_indices = encoder(dummy_image_tensor)
   decoded = decoder(encoding_indices)
 
-  assert encoding_indices.shape == (2, config.quantized_resolution ** 2)
+  assert encoding_indices.shape == (2, tiny_config.quantized_resolution ** 2)
   assert encoding_indices.dtype == torch.int64
   assert int(encoding_indices.min()) >= 0
-  assert int(encoding_indices.max()) < config.vocab_size
+  assert int(encoding_indices.max()) < tiny_config.vocab_size
   assert decoder.last_z_shape == (
     2,
-    config.z_channels,
-    config.quantized_resolution,
-    config.quantized_resolution,
+    tiny_config.z_channels,
+    tiny_config.quantized_resolution,
+    tiny_config.quantized_resolution,
   )
-  assert decoded.shape == (2, config.out_channels, config.resolution, config.resolution)
+  assert decoded.shape == (2, tiny_config.out_channels, tiny_config.resolution, tiny_config.resolution)
   assert torch.isfinite(decoded).all()
 
 
-def test_load_state_dict_from_url_delegates_to_torch_hub(monkeypatch):
+def test_load_state_dict_from_url_delegates_to_torch_hub(monkeypatch, encoder, decoder):
   """
   Instead of hitting real URLs which would cause tests to fail without a network, 
   this mocks out `torch.hub.load_state_dict_from_url` and verifies whether 
   Encoder and Decoder delegate properly to load dict states using `weights_only=True` 
   for security and memory mapping to `cpu`, effectively testing the integration.
   """
-  config = make_tiny_config()
-  encoder = Encoder(config)
-  decoder = Decoder(config)
   encoder_state_dict = {"encoder_weight": torch.tensor([1.0])}
   decoder_state_dict = {"decoder_weight": torch.tensor([2.0])}
 
@@ -163,3 +111,21 @@ def test_load_state_dict_from_url_delegates_to_torch_hub(monkeypatch):
   ]
   encoder_load_state_dict.assert_called_once_with(encoder_state_dict, strict=False)
   decoder_load_state_dict.assert_called_once_with(decoder_state_dict, assign=True)
+
+
+def test_encoder_random_dimensions(encoder, tiny_config):
+  """
+  Tests boundary limits by feeding randomly shaped non-standard
+  frames (that are divisible by the 16x downsample factor).
+  The Encoder must be able to gracefully quantize them without crashing.
+  """
+  rand_h, rand_w = 16, 64
+  
+  x = torch.randn(1, tiny_config.in_channels, rand_h, rand_w)
+  
+  encoding_indices = encoder(x)
+  
+  expected_tokens = (rand_h // 2) * (rand_w // 2)
+  
+  assert encoding_indices.shape == (1, expected_tokens)
+  assert encoding_indices.dtype == torch.int64

--- a/tests/test_vqvae_full_coverage.py
+++ b/tests/test_vqvae_full_coverage.py
@@ -1,0 +1,136 @@
+from unittest.mock import Mock
+
+import torch
+
+from utils.vqvae import (
+  CompressorConfig,
+  Decoder,
+  Encoder,
+  Upsample,
+  VectorQuantizer,
+)
+
+
+def make_tiny_config():
+  return CompressorConfig(
+    in_channels=3,
+    out_channels=3,
+    ch_mult=(1, 2),
+    attn_resolutions=(4,),
+    resolution=8,
+    num_res_blocks=1,
+    z_channels=32,
+    vocab_size=8,
+    ch=32,
+    dropout=0.0,
+  )
+
+
+def test_upsample_doubles_spatial_dimensions_and_runs_conv():
+  upsample = Upsample(in_channels=1)
+  upsample.conv.weight.data.fill_(1.0)
+  if upsample.conv.bias is not None:
+    upsample.conv.bias.data.zero_()
+
+  x = torch.ones(1, 1, 2, 2)
+
+  out = upsample(x)
+
+  expected = torch.tensor([[[[4.0, 6.0, 6.0, 4.0],
+                             [6.0, 9.0, 9.0, 6.0],
+                             [6.0, 9.0, 9.0, 6.0],
+                             [4.0, 6.0, 6.0, 4.0]]]])
+  assert out.shape == (1, 1, 4, 4)
+  assert torch.allclose(out, expected)
+
+
+def test_vector_quantizer_encode_decode_and_embed_roundtrip():
+  quantizer = VectorQuantizer(num_embeddings=3, embedding_dim=2)
+  with torch.no_grad():
+    quantizer._embedding.weight.copy_(
+      torch.tensor([
+        [0.0, 0.0],
+        [2.0, 2.0],
+        [-2.0, -2.0],
+      ])
+    )
+
+  inputs = torch.tensor([[
+    [0.1, 0.2],
+    [2.2, 1.9],
+    [-1.7, -2.1],
+  ]])
+
+  quantized, indices = quantizer(inputs)
+  decoded, decoded_indices = quantizer.decode(indices)
+  embedded = quantizer.embed(torch.tensor([[1], [0], [2]]))
+
+  assert torch.equal(indices, torch.tensor([[0, 1, 2]]))
+  assert torch.equal(decoded_indices, indices)
+  assert torch.allclose(
+    quantized,
+    torch.tensor([[
+      [0.0, 0.0],
+      [2.0, 2.0],
+      [-2.0, -2.0],
+    ]]),
+  )
+  assert torch.allclose(decoded, quantized)
+  assert torch.allclose(
+    embedded,
+    torch.tensor([
+      [2.0, 2.0],
+      [0.0, 0.0],
+      [-2.0, -2.0],
+    ]),
+  )
+
+
+def test_encoder_decoder_forward_with_tiny_config():
+  torch.manual_seed(0)
+  config = make_tiny_config()
+  encoder = Encoder(config)
+  decoder = Decoder(config)
+  x = torch.randn(2, config.in_channels, config.resolution, config.resolution)
+
+  encoding_indices = encoder(x)
+  decoded = decoder(encoding_indices)
+
+  assert encoding_indices.shape == (2, config.quantized_resolution ** 2)
+  assert encoding_indices.dtype == torch.int64
+  assert int(encoding_indices.min()) >= 0
+  assert int(encoding_indices.max()) < config.vocab_size
+  assert decoder.last_z_shape == (
+    2,
+    config.z_channels,
+    config.quantized_resolution,
+    config.quantized_resolution,
+  )
+  assert decoded.shape == (2, config.out_channels, config.resolution, config.resolution)
+  assert torch.isfinite(decoded).all()
+
+
+def test_load_state_dict_from_url_delegates_to_torch_hub(monkeypatch):
+  config = make_tiny_config()
+  encoder = Encoder(config)
+  decoder = Decoder(config)
+  encoder_state_dict = {"encoder_weight": torch.tensor([1.0])}
+  decoder_state_dict = {"decoder_weight": torch.tensor([2.0])}
+
+  load_from_url = Mock(side_effect=[encoder_state_dict, decoder_state_dict])
+  encoder_load_state_dict = Mock()
+  decoder_load_state_dict = Mock()
+
+  monkeypatch.setattr(torch.hub, "load_state_dict_from_url", load_from_url)
+  monkeypatch.setattr(encoder, "load_state_dict", encoder_load_state_dict)
+  monkeypatch.setattr(decoder, "load_state_dict", decoder_load_state_dict)
+
+  encoder.load_state_dict_from_url("https://example.com/encoder.bin", strict=False)
+  decoder.load_state_dict_from_url("https://example.com/decoder.bin", assign=True)
+
+  assert load_from_url.call_args_list == [
+    (( "https://example.com/encoder.bin",), {"map_location": "cpu", "weights_only": True}),
+    (( "https://example.com/decoder.bin",), {"map_location": "cpu", "weights_only": True}),
+  ]
+  encoder_load_state_dict.assert_called_once_with(encoder_state_dict, strict=False)
+  decoder_load_state_dict.assert_called_once_with(decoder_state_dict, assign=True)

--- a/tests/test_vqvae_utilities_and_whitebox.py
+++ b/tests/test_vqvae_utilities_and_whitebox.py
@@ -1,0 +1,88 @@
+import pytest
+import torch
+
+from utils.vqvae import Normalize, nonlinearity
+
+
+def test_nonlinearity_matches_x_sigmoid_x():
+  """
+  nonlinearity() is the swish function: x * sigmoid(x).
+  This test checks the math is correct and the shape stays the same.
+  """
+  torch.manual_seed(0)
+  x = torch.randn(2, 3, 4, 5)
+
+  out = nonlinearity(x)
+  # This is the exact formula used in vqvae.py.
+  expected = x * torch.sigmoid(x)
+
+  assert out.shape == x.shape
+  assert torch.allclose(out, expected)
+
+
+def test_normalize_constructs_groupnorm_with_expected_hyperparams():
+  """
+  Normalize() should build a GroupNorm layer with the settings we expect.
+  This is a simple constructor test (object-oriented check).
+  """
+  norm = Normalize(32)
+
+  assert isinstance(norm, torch.nn.GroupNorm)
+  assert norm.num_groups == 32
+  assert norm.num_channels == 32
+  assert norm.eps == pytest.approx(1e-6)
+  assert norm.affine is True
+
+
+def test_normalize_forward_preserves_shape_and_is_finite():
+  """
+  Normalize forward pass should not change the tensor shape.
+  It should also not produce NaN or inf values.
+  """
+  torch.manual_seed(0)
+  norm = Normalize(32)
+  x = torch.randn(2, 32, 8, 8)
+
+  out = norm(x)
+
+  assert out.shape == x.shape
+  assert torch.isfinite(out).all()
+
+
+def test_encoder_whitebox_intermediate_shapes_via_hooks(encoder, tiny_config, dummy_image_tensor):
+  """
+  White-box test. We look inside Encoder and record shapes from a few layers.
+  This helps catch silent shape bugs even if the forward pass still runs.
+
+  We use forward hooks to capture outputs without changing the model code.
+  """
+  seen = {}
+
+  def save_shape(name):
+    def _hook(_module, _inputs, output):
+      # Store the output shape for this layer name.
+      seen[name] = tuple(output.shape)
+    return _hook
+
+  # Attach hooks to internal layers we care about.
+  h1 = encoder.conv_in.register_forward_hook(save_shape("conv_in"))
+  h2 = encoder.conv_out.register_forward_hook(save_shape("conv_out"))
+  h3 = encoder.quant_conv.register_forward_hook(save_shape("quant_conv"))
+  try:
+    # Run a normal forward pass.
+    encoding_indices = encoder(dummy_image_tensor)
+  finally:
+    # Always remove hooks so they do not leak into other tests.
+    h1.remove()
+    h2.remove()
+    h3.remove()
+
+  # With tiny_config (resolution=8), the encoder downsamples once.
+  # So the spatial size at the end should be 4x4 (quantized_resolution).
+  assert seen["conv_in"] == (2, tiny_config.ch, tiny_config.resolution, tiny_config.resolution)
+  assert seen["conv_out"] == (2, tiny_config.z_channels, tiny_config.quantized_resolution, tiny_config.quantized_resolution)
+  assert seen["quant_conv"] == (2, tiny_config.z_channels, tiny_config.quantized_resolution, tiny_config.quantized_resolution)
+
+  # Output indices are flattened tokens. Token count should be h*w.
+  assert encoding_indices.shape == (2, tiny_config.quantized_resolution * tiny_config.quantized_resolution)
+  assert encoding_indices.dtype == torch.int64

--- a/utils/vqvae.py
+++ b/utils/vqvae.py
@@ -300,24 +300,113 @@ class Decoder(nn.Module):
     self.conv_out = torch.nn.Conv2d(block_in, self.config.out_channels, kernel_size=3, stride=1, padding=1)
 
   def forward(self, encoding_indices):
-    # run the decoder part of VQ
-    z, _ = self.quantize.decode(encoding_indices)
-    z = rearrange(z, 'b (h w) c -> b c h w', w=self.config.quantized_resolution)
-    z = self.post_quant_conv(z)
-    self.last_z_shape = z.shape
+    # ============================================================================
+    # BIG PICTURE
+    # ----------------------------------------------------------------------------
+    # The decoder is the second half of a VQ-VAE. The encoder squashed a
+    # (3, 128, 256) RGB driving frame (~98k numbers) down into just 128 integers.
+    # Our job here is to expand those 128 integers back into a (3, 128, 256)
+    # image. That's a ~770x compression ratio, so the decoder has to do serious
+    # heavy lifting.
+    #
+    # The strategy is "grow and refine":
+    #   1. Look the 128 integers up in a learned codebook to get feature vectors.
+    #   2. Reshape into a tiny 8x16 "feature postage stamp" with 256 channels.
+    #   3. Do some global reasoning at this tiny resolution (mid stack).
+    #   4. Repeatedly: refine the feature map with ResnetBlocks, then double its
+    #      spatial size with an Upsample. Do this 4 times to grow 8x16 -> 128x256.
+    #   5. Collapse the channel dim from 128 down to 3 (RGB) and rescale to pixels.
+    # ============================================================================
 
-    # timestep embedding
+    # Input: encoding_indices is (B, 128) int64: codebook IDs from the encoder.
+    # Goal: reconstruct an RGB image of shape (B, 3, 128, 256) in pixel range [0, 255].
+
+    # 1. VQ DECODE -- the codebook lookup.
+    #    The VectorQuantizer holds a learned codebook of 1024 vectors, each of size
+    #    256. You can think of each codebook entry as a learned "visual concept" --
+    #    a tiny piece of a feature map. The encoder didn't store pixels; it stored
+    #    128 integers that say "use concept #427 here, concept #12 here, ...".
+    #    That's why compression works so well: 10 bits (0..1023) references a
+    #    whole 256-dim feature.
+    #    Shape goes from (B, 128) -> (B, 128, 256), i.e. b (h w) c.
+    z, _ = self.quantize.decode(encoding_indices)
+
+    # 2. SEQUENCE -> 2D FEATURE MAP.
+    #    After the lookup we have 128 token-vectors per image, but an image is 2D,
+    #    not a flat sequence. We reshape into a tiny 2D grid: 256 channels, 8 rows,
+    #    16 columns -- a "postage-stamp-sized feature image" that's only 8x16 but
+    #    very deep. Why 8x16? Because the encoder downsampled the original 128x256
+    #    image by 16x in each direction (128/16=8, 256/16=16). The decoder will
+    #    spend the rest of forward() undoing that.
+    #    With w=quantized_resolution=16 and h*w=128, h=8, so we get (B, 256, 8, 16).
+    z = rearrange(z, 'b (h w) c -> b c h w', w=self.config.quantized_resolution)
+
+    # 3. POST-QUANT CONV.
+    #    1x1 conv that mirrors the encoder's quant_conv (kept channel count at
+    #    z_channels=256). It's a small learned linear projection on each spatial
+    #    location -- think of it as a "translator" between the codebook space and
+    #    the convolutional feature space the rest of the decoder expects.
+    z = self.post_quant_conv(z)
+    self.last_z_shape = z.shape  # cached for tests / debugging
+
+    # No timestep conditioning in this model: temb stays None throughout.
+    # (This codebase reuses an architecture originally designed for diffusion
+    # models, where temb would carry the diffusion timestep. We don't need it.)
     temb = None
 
-    # z to block_in
+    # 4. CONV_IN -- lift channels into the working width.
+    #    conv_in lifts channels from z_channels (256) up to block_in =
+    #    ch * ch_mult[-1] = 128 * 4 = 512. Spatial dims unchanged:
+    #    (B, 256, 8, 16) -> (B, 512, 8, 16). The rest of the network operates at
+    #    this wider 512-channel representation at the lowest resolution.
     h = self.conv_in(z)
 
-    # middle
+    # 5. MID STACK -- the "deepest thinking" layer.
+    #    ResnetBlock -> AttnBlock -> ResnetBlock, all at 512 channels and 8x16
+    #    spatial. This runs at the lowest resolution and does the most global
+    #    reasoning before any spatial growth begins. The AttnBlock here lets every
+    #    one of the 8*16=128 spatial positions "look at" every other position and
+    #    exchange information -- the model figures out the overall layout (where
+    #    the road is, where the horizon is, etc.) before it starts adding details.
+    #    Attention is expensive (cost scales with pixels^2), so we only afford it
+    #    at this tiny resolution.
     h = self.mid.block_1(h, temb)
     h = self.mid.attn_1(h)
     h = self.mid.block_2(h, temb)
 
-    # upsampling
+    # 6. UPSAMPLING TOWER -- grow the postage stamp into a full image.
+    #    We iterate i_level = 4, 3, 2, 1, 0 (reversed) to walk back up the
+    #    resolution pyramid the encoder walked down. At each level we do:
+    #
+    #       (a) Run (num_res_blocks + 1) = 3 ResnetBlocks. A ResnetBlock is
+    #           a small subnetwork (norm -> swish -> conv -> norm -> swish ->
+    #           conv) that learns to ADD detail to the current feature map
+    #           rather than replace it (the "residual" output is x + h). This
+    #           is what invents new structure at the current scale.
+    #
+    #       (b) Optionally run AttnBlocks interleaved with the ResnetBlocks --
+    #           but ONLY at i_level=4, where curr_res=16 happens to be in
+    #           attn_resolutions. At higher resolutions attention would be
+    #           prohibitively expensive, so we skip it.
+    #
+    #       (c) Double the spatial dims with a nearest-neighbor Upsample
+    #           followed by a 3x3 conv (see Upsample.forward). The nearest-
+    #           neighbor step copies each pixel into a 2x2 block; the conv
+    #           smooths the result so it doesn't look blocky. Skipped at
+    #           i_level=0 because we're already at full resolution.
+    #
+    #    Notice that channels SHRINK as resolution GROWS (512 -> 512 -> 256 ->
+    #    256 -> 128). This keeps the memory footprint roughly constant and
+    #    matches the intuition that low-res pixels carry complex semantic
+    #    concepts (need many channels) while high-res pixels mostly just need
+    #    to know "what color am I" (few channels suffice).
+    #
+    #    Channel and shape progression:
+    #      i_level=4: 512->512, attn x3, upsample -> (B, 512, 16, 32)
+    #      i_level=3: 512->256, 256->256, 256->256, upsample -> (B, 256, 32, 64)
+    #      i_level=2: 256->256 x3, upsample -> (B, 256, 64, 128)
+    #      i_level=1: 256->128, 128->128, 128->128, upsample -> (B, 128, 128, 256)
+    #      i_level=0: 128->128 x3, NO upsample (already at full resolution)
     for i_level in reversed(range(self.config.num_resolutions)):
       for i_block in range(self.config.num_res_blocks+1):
         h = self.up[i_level].block[i_block](h, temb)
@@ -326,11 +415,22 @@ class Decoder(nn.Module):
       if i_level != 0:
         h = self.up[i_level].upsample(h)
 
+    # 7. OUTPUT HEAD -- collapse 128 channels down to 3 (RGB).
+    #    GroupNorm -> swish -> 3x3 conv. We're now at full spatial resolution
+    #    (128x256) with 128 channels per pixel; the final 3x3 conv just learns
+    #    a per-pixel mapping from those 128 features to (R, G, B).
+    #    Shape: (B, 128, 128, 256) -> (B, 3, 128, 256). Output is float in
+    #    roughly [-1, 1] because that's the range the network was trained on.
     h = self.norm_out(h)
     h = nonlinearity(h)
     h = self.conv_out(h)
 
-    # scale
+    # 8. RESCALE TO PIXELS.
+    #    The network's natural output is in [-1, 1]. Map that linearly to
+    #    [0, 255] so the result looks like an 8-bit image. We do NOT clip or
+    #    cast to uint8 here -- the caller is responsible for that (see
+    #    utils/video.transpose_and_clip), which keeps this function pure-tensor
+    #    and friendly for downstream loss computations.
     return ((h + 1.0) / 2.0) * 255.
 
   def load_state_dict_from_url(self, url='https://huggingface.co/commaai/commavq-gpt2m/resolve/main/decoder_pytorch_model.bin', *args, **kwargs):


### PR DESCRIPTION
## Summary
This PR adds a few missing tests for vqvae.py.
It tests nonlinearity, Normalize, and Encoder internal shapes using hooks.
## Why
We want better coverage and to match the test plan section 3.
This helps catch shape bugs early and makes the code safer to change.
## Tests
./venv/bin/python -m pytest -q